### PR TITLE
Rough example  to parse HEP encapsulated UDP on Node.

### DIFF
--- a/example/hep.js
+++ b/example/hep.js
@@ -6,16 +6,18 @@ https://code.google.com/p/homer/wiki/HEP
 
 */
 
-var sip = require('sipcore');
+var sip = require('..');
+var udp = require('../lib/protocol/node/udp');
+
 var transport = sip.createTransport();
+var protocol = sip.createProtocol(udp.Protocol);
 
-process.env.JS_ENV = 'node';
+protocol.format = 'hep1';
+transport.register(protocol, 9060, '0.0.0.0');
 
-transport.register('udpHEP1', 9060, "0.0.0.0");
 transport.listen(function (listenState) {
-  console.log('* UDP listening...', listenState.udpHEP1 ? 'ok' : 'failed');
+  console.log('* UDP listening...', listenState.udp ? 'ok' : 'failed');
 });
-
 
 transport.on('message', function (msg) {
   console.log('-- new SIP message');

--- a/example/hep.js
+++ b/example/hep.js
@@ -1,0 +1,23 @@
+
+/*
+Example that can recieve V1 HEP packets from a capture source such as Kamailio and Freeswitch.
+https://code.google.com/p/homer/wiki/HEP
+
+
+*/
+
+var sip = require('sipcore');
+var transport = sip.createTransport();
+
+process.env.JS_ENV = 'node';
+
+transport.register('udpHEP1', 9060, "0.0.0.0");
+transport.listen(function (listenState) {
+  console.log('* UDP listening...', listenState.udpHEP1 ? 'ok' : 'failed');
+});
+
+
+transport.on('message', function (msg) {
+  console.log('-- new SIP message');
+  console.log(msg);
+});

--- a/lib/protocol/node/udp.js
+++ b/lib/protocol/node/udp.js
@@ -19,21 +19,18 @@
 
 var EventEmitter = require('events').EventEmitter;
 var dgram = require('dgram');
-var inherits = require('util').inherits;
-var SIP = require('../../..');
 
 
 /**
  * @constructor
  * @implements {Protocol}
  */
-function UDP_Protocol () {
+function UDP_Protocol (init) {
 
-  SIP.Protocol.call(this);
+  init.call(this);
 
-  this.name = 'udpHEP1';
+  this.name = 'udp';
   this.reliable = false;
-  this.format='hep1'
 
   this.socket = dgram.createSocket('udp4');
 
@@ -44,9 +41,6 @@ function UDP_Protocol () {
     that.emit('close');
   });
 }
-
-
-inherits(UDP_Protocol, SIP.Protocol);
 
 
 /**
@@ -73,8 +67,6 @@ UDP_Protocol.prototype.bind = function (port, addr, cb) {
   });
 
   socket.on('message', function (data, rinfo) {
-  
-  
     that.emit('message', data, rinfo);
   });
 
@@ -115,6 +107,4 @@ UDP_Protocol.prototype.close = function (cb) {
 };
 
 
-exports.createProtocol = function () {
-  return new UDP_Protocol;
-};
+exports.Protocol = UDP_Protocol;

--- a/lib/protocol/node/udpHEP1.js
+++ b/lib/protocol/node/udpHEP1.js
@@ -1,0 +1,120 @@
+/*
+  SIPCore.js - General purpose SIP library for JavaScript.
+  Copyright (C) 2013 Gregor Mazovec
+
+  SIPCore.js is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or any later version.
+
+  SIPCore.js is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with SIPCore.js. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+var EventEmitter = require('events').EventEmitter;
+var dgram = require('dgram');
+var inherits = require('util').inherits;
+var SIP = require('../../..');
+
+
+/**
+ * @constructor
+ * @implements {Protocol}
+ */
+function UDP_Protocol () {
+
+  SIP.Protocol.call(this);
+
+  this.name = 'udpHEP1';
+  this.reliable = false;
+  this.format='hep1'
+
+  this.socket = dgram.createSocket('udp4');
+
+  var that = this;
+
+  this.socket.on('close', function () {
+    that.listenState = 0;
+    that.emit('close');
+  });
+}
+
+
+inherits(UDP_Protocol, SIP.Protocol);
+
+
+/**
+ * @param {string} addr
+ * @param {number} port
+ * @param {function(Socket)} cb
+ */
+UDP_Protocol.prototype.bind = function (port, addr, cb) {
+
+  var that = this;
+  var socket = this.socket;
+
+  socket.bind(port, addr, function () {
+    
+    var sockAddress = socket.address();
+
+    that.addr = sockAddress.address;
+    that.port = sockAddress.port;
+
+    that.listenState = 1;
+
+    if (cb) cb(1);
+    that.emit('listening');
+  });
+
+  socket.on('message', function (data, rinfo) {
+  
+  
+    that.emit('message', data, rinfo);
+  });
+
+};
+
+
+/**
+ * @param {string} data Raw message data.
+ * @param {string=} addr Target IP address.
+ * @param {number=} port Target port number.
+ * @param {function(Socket)=} cb Callback called after connection established.
+ */
+UDP_Protocol.prototype.send = function (data, addr, port, cb) {
+
+  var buf = new Buffer(data);
+
+  this.socket.send(buf, 0, buf.length, port, addr, function (err, bytes) {
+    if (cb) cb(err);
+  });
+
+};
+
+
+UDP_Protocol.prototype.close = function (cb) {
+
+  this.listenState = -1;
+
+  if (cb) this.socket.once('close', function () {
+    cb(0);
+  });
+
+  var that = this;
+
+  // close event is called is same tick - mimic async behaviour
+  process.nextTick(function () {
+    that.socket.close();
+  });
+};
+
+
+exports.createProtocol = function () {
+  return new UDP_Protocol;
+};

--- a/lib/sip.js
+++ b/lib/sip.js
@@ -1841,37 +1841,31 @@ Transport.prototype.register = function (protocol, port, addr) {
   // Listen for new messages from protocol layer.
   protocol.on('message', function (data, rinfo) {
 
-    // Message are parsed as JSON or plain text or hep.
+    // Message are parsed as JSON or plain text or HEP.
     try {
-     if(protocol.format === 'hep1')
-		{
-			hep = {
-				sourcePort:data.readUInt16BE(4),
-				destPort:data.readUInt16BE(6),
-				fromIp:data.readUInt8(8) + "."+data.readUInt8(9)   + "."+   data.readUInt8(10) + "."+data.readUInt8(11),
-				toIp:data.readUInt8(12) + "."+data.readUInt8(13)+ "."+data.readUInt8(14) + "."+data.readUInt8(15)
-			};
-			
+      if (protocol.format === 'hep1') {
+	var read = data.readUInt8;
+        var hep = {
+          sourcePort: data.readUInt16BE(4),
+          destPort: data.readUInt16BE(6),
+          fromIp: read(8) + '.' + read(9) + '.' + read(10) + '.' + read(11),
+          toIp: read(12) + '.' + read(13)+ '.' + read(14) + '.' + read(15)
+        };
 
-		  if(data.readUInt8(16) === 10 || data.readUInt8(16) === 13) // Packets with only CR LF values occur I am not sure when I think they are stun or keep alive packets being forwarded.
-		  {
-			console.log("Blank HEP:"+JSON.stringify(hep));
-			return;//finish Processing
-		  }
-		  
-		  sipData=data.slice(16);
-		  
-		  var mobj = parseMessage(sipData.toString());
-		  mobj["hep"]=hep;
-		}else if(protocol.format == 'json')
-		{
-			var mobj =JSON.parse(data);
-		}else
-		{
-			var mobj = parseMessage(data.toString());
-		}
-		
+	// Packets with only CR LF values occur I am not sure when I think they are stun or keep alive packets being forwarded.
+        if(read(16) === 10 || read(16) === 13) {
+          console.log('Blank HEP:', JSON.stringify(hep));
+          return;
+        }
 
+        var sipData = data.slice(16);
+        var mobj = parseMessage(sipData.toString());
+        mobj['hep'] = hep;
+      } else if (protocol.format == 'json') {
+        var mobj = JSON.parse(data);
+      } else {
+        var mobj = parseMessage(data.toString());
+      }
     }
     catch (e) {
       // @pass

--- a/lib/sip.js
+++ b/lib/sip.js
@@ -1841,10 +1841,37 @@ Transport.prototype.register = function (protocol, port, addr) {
   // Listen for new messages from protocol layer.
   protocol.on('message', function (data, rinfo) {
 
-    // Message are parsed as JSON or plain text.
+    // Message are parsed as JSON or plain text or hep.
     try {
-      var mobj = (protocol.format == 'json') ?
-        JSON.parse(data) : parseMessage(data.toString());
+     if(protocol.format === 'hep1')
+		{
+			hep = {
+				sourcePort:data.readUInt16BE(4),
+				destPort:data.readUInt16BE(6),
+				fromIp:data.readUInt8(8) + "."+data.readUInt8(9)   + "."+   data.readUInt8(10) + "."+data.readUInt8(11),
+				toIp:data.readUInt8(12) + "."+data.readUInt8(13)+ "."+data.readUInt8(14) + "."+data.readUInt8(15)
+			};
+			
+
+		  if(data.readUInt8(16) === 10 || data.readUInt8(16) === 13) // Packets with only CR LF values occur I am not sure when I think they are stun or keep alive packets being forwarded.
+		  {
+			console.log("Blank HEP:"+JSON.stringify(hep));
+			return;//finish Processing
+		  }
+		  
+		  sipData=data.slice(16);
+		  
+		  var mobj = parseMessage(sipData.toString());
+		  mobj["hep"]=hep;
+		}else if(protocol.format == 'json')
+		{
+			var mobj =JSON.parse(data);
+		}else
+		{
+			var mobj = parseMessage(data.toString());
+		}
+		
+
     }
     catch (e) {
       // @pass

--- a/lib/sip.js
+++ b/lib/sip.js
@@ -1814,10 +1814,37 @@ Transport.prototype.register = function (protocol, port, addr) {
   // Listen for new messages from protocol layer.
   protocol.on('message', function (data, rinfo) {
 
-    // Message are parsed as JSON or plain text.
+    // Message are parsed as JSON or plain text or hep.
     try {
-      var mobj = (protocol.format == 'json') ?
-        JSON.parse(data) : parseMessage(data.toString());
+     if(protocol.format === 'hep1')
+		{
+			hep = {
+				sourcePort:data.readUInt16BE(4),
+				destPort:data.readUInt16BE(6),
+				fromIp:data.readUInt8(8) + "."+data.readUInt8(9)   + "."+   data.readUInt8(10) + "."+data.readUInt8(11),
+				toIp:data.readUInt8(12) + "."+data.readUInt8(13)+ "."+data.readUInt8(14) + "."+data.readUInt8(15)
+			};
+			
+
+		  if(data.readUInt8(16) === 10 || data.readUInt8(16) === 13) // Packets with only CR LF values occur I am not sure when I think they are stun or keep alive packets being forwarded.
+		  {
+			console.log("Blank HEP:"+JSON.stringify(hep));
+			return;//finish Processing
+		  }
+		  
+		  sipData=data.slice(16);
+		  
+		  var mobj = parseMessage(sipData.toString());
+		  mobj["hep"]=hep;
+		}else if(protocol.format == 'json')
+		{
+			var mobj =JSON.parse(data);
+		}else
+		{
+			var mobj = parseMessage(data.toString());
+		}
+		
+
     }
     catch (e) {
       // @pass


### PR DESCRIPTION
Rough example of how this could be modified to parse HEP encapsulated packets.

I hacked together code here inside  the npm version on node. This allows me to use your library to decode message captured by HEP compatable agents such as Kamailio and Freeswitch. 

What do you think?

https://code.google.com/p/homer/wiki/HEP
